### PR TITLE
Fix inifinite loop in the visualizer in Edge

### DIFF
--- a/src/visualization/parsers/layout.ts
+++ b/src/visualization/parsers/layout.ts
@@ -161,7 +161,13 @@ export default class Layout implements IParser {
         var node = <HTMLElement>this.layouts[state.index];
         if (node) {
             // First remove all its existing attributes
-            while (node.attributes && node.attributes.length > 0) node.removeAttribute(node.attributes[0].name);
+            if (node.attributes) { 
+                var attributes = node.attributes.length;
+                while (node.attributes && attributes > 0) {
+                    node.removeAttribute(node.attributes[0].name);
+                    attributes--;
+                } 
+            }       
             // Then, update attributes from the new received event state
             this.attributes(node, state.attributes);
             // Special handling for image nodes


### PR DESCRIPTION
Edge doesn't decrement attributes.length when node.removeAttribute(node.attributes[0].name) is called, so the while loop would go indefinitely. 