### PR TITLE
Fix PermissionDenied error in Visualizer in Edge

### DIFF
--- a/src/visualization/parsers/boxmodel.ts
+++ b/src/visualization/parsers/boxmodel.ts
@@ -85,6 +85,7 @@ export default class BoxModel implements IParser {
             case "*DOC*":
                 let docState = state as IDoctypeLayoutState;
                 if (typeof XMLSerializer !== "undefined") {
+                    this.layouts = {};
                     doc.open();
                     doc.write(new XMLSerializer().serializeToString(
                         this.document.implementation.createDocumentType(

--- a/src/visualization/parsers/layout.ts
+++ b/src/visualization/parsers/layout.ts
@@ -83,6 +83,7 @@ export default class Layout implements IParser {
             case "*DOC*":
                 state = layoutState as IDoctypeLayoutState;
                 if (typeof XMLSerializer !== "undefined") {
+                    this.layouts = {};
                     doc.open();
                     doc.write(new XMLSerializer().serializeToString(
                         this.document.implementation.createDocumentType(


### PR DESCRIPTION
In Edge, doc.open renders all items in the layouts array inaccessibly once it's called.  Since we don't need those items any more at this point, this change clears out the array.